### PR TITLE
Build: Add build analytics option for research

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1598,6 +1598,9 @@ EOS_TARGET_PACKAGE := $(PRODUCT_OUT)/Euphoria-OS-$(ROM_VERSION).zip
 .PHONY: otapackage bacon
 otapackage: $(INTERNAL_OTA_PACKAGE_TARGET)
 bacon: otapackage
+	ifeq ($(SHARE_BUILD_ANALYTICS),true)
+		$(shell ./build/tools/BuildAnalytics.sh $(STARTTIME))
+	endif
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(EOS_TARGET_PACKAGE)
 	$(hide) $(MD5SUM) $(EOS_TARGET_PACKAGE) > $(EOS_TARGET_PACKAGE).md5sum
 	@echo -e ${CL_GRN}"Package Complete: $(EOS_TARGET_PACKAGE)"${CL_RST}

--- a/core/dumpvar.mk
+++ b/core/dumpvar.mk
@@ -83,6 +83,7 @@ $(info   HOST_OS=$(HOST_OS))
 $(info   HOST_OS_EXTRA=$(HOST_OS_EXTRA))
 $(info   HOST_BUILD_TYPE=$(HOST_BUILD_TYPE))
 $(info   BUILD_ID=$(BUILD_ID))
+$(info   SHARE_BUILD_ANALYTICS=$(SHARE_BUILD_ANALYTICS))
 $(info   OUT_DIR=$(OUT_DIR))
 $(info ============================================)
 endif

--- a/core/main.mk
+++ b/core/main.mk
@@ -58,6 +58,14 @@ PWD := $(shell pwd)
 TOP := .
 TOPDIR :=
 
+export STARTTIME := $(shell date +%s)
+
+ifneq ($(wildcard ./out/target/product/.*),)
+	ifeq ($(SHARE_BUILD_ANALYTICS), true)
+		export SHARE_BUILD_ANALYTICS := false
+	endif
+endif
+
 BUILD_SYSTEM := $(TOPDIR)build/core
 
 # This is the default target.  It must be the first declared target.

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,3 +1,4 @@
+export INPUT_DIR=$(pwd)
 function hmm() {
 cat <<EOF
 Invoke ". build/envsetup.sh" from your shell to add the following functions to your environment:

--- a/tools/BuildAnalytics.sh
+++ b/tools/BuildAnalytics.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# This script collect build info and sends it to my server
+# Copyright (C) 2015 Jacob McSwain
+#
+# This file is part of BuildAnalytics.
+#
+# BuildAnalytics is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation.
+#
+# BuildAnalytics is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BuildAnalytics. If not, see <http://www.gnu.org/licenses/>.
+
+
+STARTTIME=$1
+ENDTIME=$(date +%s)
+
+PROC_MODEL=$(grep "model name" /proc/cpuinfo | awk -F':' '{print $2}' | head -n 1 | xargs | sed s/@/at/g)
+NUMBER_OF_PROCS=$(grep "physical id" /proc/cpuinfo | sort -u | wc -l)
+
+DISTRO="Unix-like"
+
+if [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    DISTRO=$DISTRIB_DESCRIPTION
+elif [ -f /etc/debian_version ]; then
+    DISTRO="Debian $(cat /etc/debian_version)"
+elif [ -f /etc/redhat-release ]; then
+    DISTRO="Red Hat"
+elif [ -f /etc/SUSE-release ]; then
+    DISTRO="SUSE"
+elif [ -f /etc/fedora-release ]; then
+    DISTRO="Fedora"
+elif [ -f /etc/slackware-release ]; then
+    DISTRO="Slackware"
+elif [ -f /etc/mandrake-release ]; then
+    DISTRO="Mandrake"
+elif [ -f /etc/yellowdog-release ]; then
+    DISTRO="Yellow Dog"
+elif [ -f /etc/gentoo-release ]; then
+    DISTRO="Gentoo"
+else
+    DISTRO=$(uname -s)
+fi
+
+BUILD_USING_CCACHE=$USE_CCACHE
+CCACHE_SIZE=$(ccache -s | grep "cache size" | head -1 | awk -F' ' '{print $3 " " $4}')
+DISK_INFO=$(lsblk -d -o name,rota)
+NUM_DISKS=$(lsblk -d -o name,rota | wc -l)
+
+SSD_DISKS=""
+HDD_DISKS=""
+
+COUNTER=2
+while [ $COUNTER -lt $((NUM_DISKS+1)) ]; do
+            TMPDISKINFO=$(echo "$DISK_INFO" | sed -n "$COUNTER p")
+            if [[ "$TMPDISKINFO" == *0 ]]
+                then
+                    if [ $COUNTER -eq 2 ]
+                        then
+                          SSD_DISKS=$(echo "$TMPDISKINFO" | awk -F' ' '{print $1}')
+                        else
+                          SSD_DISKS=$SSD_DISKS:$(echo "$TMPDISKINFO" | awk -F' ' '{print $1}')
+                    fi
+                else
+                    if [ $COUNTER -eq 2 ]
+                        then
+                          HDD_DISKS=$(echo "$TMPDISKINFO" | awk -F' ' '{print $1}')
+                        else
+                          HDD_DISKS=$HDD_DISKS:$(echo "$TMPDISKINFO" | awk -F' ' '{print $1}')
+                    fi
+            fi
+            let COUNTER=COUNTER+1
+        done
+
+OUT_VOLUME=$(df "$OUT_DIR" | sed -n "2p" | awk -F' ' '{print $1}')
+SOURCE_VOLUME=$(df "$INPUT_DIR" | sed -n "2p" | awk -F' ' '{print $1}')
+
+TOTAL_MEMORY=$(free -t -h | sed -n "2p" | awk -F' ' '{print $2}')
+PLATFORM=$(python -c "import platform; print(platform.platform())")
+
+BUILD_TIME=$((ENDTIME-STARTTIME))
+
+USING_PREBUILT_CHROMIUM=$PRODUCT_PREBUILT_WEBVIEWCHROMIUM
+
+BASEURL="http://desolationrom.com/regAndroidBuild.php?"
+ARGSURL="cpu=$PROC_MODEL&numprocs=$NUMBER_OF_PROCS&distro=$DISTRO&using_ccache=$BUILD_USING_CCACHE&ccache_size=$CCACHE_SIZE&ssds=$SSD_DISKS&hdds=$HDD_DISKS&outvolume=$OUT_VOLUME&sourcevolume=$SOURCE_VOLUME&totalmemory=$TOTAL_MEMORY&platform=$PLATFORM&prebuiltchromium=$USING_PREBUILT_CHROMIUM&buildtime=$BUILD_TIME"
+curl "$BASEURL""$ARGSURL"


### PR DESCRIPTION
This is a script that sends hardware info and build times to a server in order to aggregate it, and be able to make a wizard to tell $
This is ONLY info about how long it took to build and the hardware related to build performance
It is defaulted off and the way to turn it on is exporting SHARE_BUILD_ANALYTICS to true in a device tree.

The info collected is as follows:
The CPU Model
The number of physical CPU's installed
The distro you are using
Whether you are using ccache, and the size of it
The SSD Names in your system (e.g. /dev/sda)
The HDD Names in you system (e.g. /dev/sdb)
The disk output is going to
The disk input is coming from
The total memory installed
The platform(as shown when you run lunch $device)
Whether you use a prebuilt chromium
And the build time in seconds

You can see the source in this commit, and also see the server-side script on
https://github.com/USA-RedDragon/BuildAnalytics

I hope you will export this to true in order to further this research and give a good, accurate representations of Android build time
